### PR TITLE
Fix missing map texts in event scripts

### DIFF
--- a/data/event_scripts.s
+++ b/data/event_scripts.s
@@ -1798,6 +1798,11 @@ EventScript_VsSeekerChargingDone::
 	.include "data/text/kanto_pokedex_rating.inc"
 	.include "data/text/sign_lady.inc"
 	.include "data/scripts/kanto_pokedex_rating.inc"
+    .include "data/maps/PalletTown/text.inc"
+    .include "data/maps/PalletTown_PlayersHouse_1F/text.inc"
+    .include "data/maps/PalletTown_PlayersHouse_2F/text.inc"
+    .include "data/maps/PalletTown_RivalsHouse/text.inc"
+    .include "data/maps/Route1/text.inc"
     .include "data/maps/PalletTown_ProfessorOaksLab/text.inc"
 
 EventScript_Return::


### PR DESCRIPTION
## Summary
- include additional text files in `event_scripts.s`

## Testing
- `make -j4` *(fails: `arm-none-eabi-gcc: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687d743345a88323a8d9b9c2e3ba7f01