### PR TITLE
Fix missing cross constants

### DIFF
--- a/data/event_scripts.s
+++ b/data/event_scripts.s
@@ -53,6 +53,7 @@
 #include "constants/songs.h"
 #include "constants/sound.h"
 #include "constants/species.h"
+#include "constants/npc_text_colors.h"
 #include "constants/trade.h"
 #include "constants/trainer_hill.h"
 #include "constants/trainers.h"
@@ -107,7 +108,8 @@ gStdScripts::
 	.4byte Std_ObtainDecoration        @ STD_OBTAIN_DECORATION
 	.4byte Std_RegisteredInMatchCall   @ STD_REGISTER_MATCH_CALL
 	.4byte Std_MsgboxGetPoints         @ MSGBOX_GETPOINTS
-	.4byte Std_MsgboxPokenav           @ MSGBOX_POKENAV
+        .4byte Std_MsgboxPokenav           @ MSGBOX_POKENAV
+        .4byte Std_ReceivedItem            @ STD_RECEIVED_ITEM
 gStdScripts_End::
 
 	.include "data/maps/AbandonedShip_CaptainsOffice/scripts.inc"
@@ -1350,8 +1352,11 @@ Common_EventScript_ShowBagIsFull::
 	end
 
 Common_EventScript_BagIsFull::
-	msgbox gText_TooBadBagIsFull, MSGBOX_DEFAULT
-	return
+        msgbox gText_TooBadBagIsFull, MSGBOX_DEFAULT
+        return
+
+EventScript_BagIsFull::
+        goto Common_EventScript_BagIsFull
 
 Common_EventScript_ShowNoRoomForDecor::
 	msgbox gText_NoRoomLeftForAnother, MSGBOX_DEFAULT
@@ -1363,8 +1368,26 @@ Common_EventScript_NoRoomForDecor::
 	return
 
 Common_EventScript_SetAbnormalWeather::
-	setweather WEATHER_ABNORMAL
-	return
+        setweather WEATHER_ABNORMAL
+        return
+
+EventScript_RestorePrevTextColor::
+        return
+
+EventScript_ReleaseEnd::
+        release
+        end
+
+EventScript_ChangePokemonNickname::
+        special ChangePokemonNickname
+        return
+
+Std_ReceivedItem::
+        return
+
+Route29_EventScript_ItemPotion::
+        itemball ITEM_POTION
+        end
 
 Common_EventScript_PlayGymBadgeFanfare::
 	playfanfare MUS_OBTAIN_BADGE

--- a/data/maps/PalletTown_ProfessorOaksLab/text.inc
+++ b/data/maps/PalletTown_ProfessorOaksLab/text.inc
@@ -347,11 +347,15 @@ PalletTown_ProfessorOaksLab_Text_OakMustReallyWorkToFillPokedex::
     .string "undertaking in POKéMON history!$"
 
 PalletTown_ProfessorOaksLab_Text_RivalIllCompleteThePokedex::
-    .string "{RIVAL}: Gramps, calm down.\n"
-    .string "Don't get so excited.\p"
-    .string "I'll get the POKéDEX completed,\n"
-    .string "don't you worry about a thing.\p"
-    .string "I think I'll try looking around\n"
-    .string "ONE ISLAND first…\p"
-    .string "Anyways, I'm outta here!$"
+        .string "{RIVAL}: Gramps, calm down.\n"
+        .string "Don't get so excited.\p"
+        .string "I'll get the POKéDEX completed,\n"
+        .string "don't you worry about a thing.\p"
+        .string "I think I'll try looking around\n"
+        .string "ONE ISLAND first…\p"
+        .string "Anyways, I'm outta here!$"
+
+Text_GiveNicknameToThisMon::
+        .string "Do you want to give a nickname to\n"
+        .string "this Pokémon?$"
 

--- a/include/constants/event_objects.h
+++ b/include/constants/event_objects.h
@@ -319,6 +319,13 @@
 // is 65519, but even considering follower Pokémon, this should be more than enough :)
 #define NUM_OBJ_EVENT_GFX                        311
 
+// Compatibility aliases
+#define OBJ_EVENT_GFX_CLERK      OBJ_EVENT_GFX_KANTO_CLERK
+#define OBJ_EVENT_GFX_BOY        OBJ_EVENT_GFX_LITTLE_BOY
+#define OBJ_EVENT_GFX_TOWN_MAP   OBJ_EVENT_GFX_KANTO_TOWN_MAP
+#define OBJ_EVENT_GFX_WORKER_F   OBJ_EVENT_GFX_WOMAN_1
+#define OBJ_EVENT_GFX_RIVAL      OBJ_EVENT_GFX_RIVAL_GOLD_NORMAL
+
 
 // These are dynamic object gfx ids.
 // They correspond with the values of the VAR_OBJ_GFX_ID_X vars.

--- a/include/constants/npc_text_colors.h
+++ b/include/constants/npc_text_colors.h
@@ -1,0 +1,11 @@
+#ifndef GUARD_CONSTANTS_NPC_TEXT_COLORS_H
+#define GUARD_CONSTANTS_NPC_TEXT_COLORS_H
+
+// These values are unused in Emerald but required for scripts that set text colors.
+#define NPC_TEXT_COLOR_MALE    0
+#define NPC_TEXT_COLOR_FEMALE  0
+#define NPC_TEXT_COLOR_NEUTRAL 0
+
+#define MSG_COLOR_BLUE         0
+
+#endif // GUARD_CONSTANTS_NPC_TEXT_COLORS_H

--- a/include/constants/songs.h
+++ b/include/constants/songs.h
@@ -586,4 +586,10 @@
 #define PHONEME_ID(song)            ((song) - FIRST_PHONEME_SONG)
 #define PHONEME_ID_NONE             0xFF
 
+// Aliases for compatibility with FireRed/LeafGreen naming
+#define MUS_ENCOUNTER_RIVAL  MUS_RG_ENCOUNTER_RIVAL
+#define MUS_RIVAL_EXIT       MUS_RG_RIVAL_EXIT
+#define MUS_OBTAIN_KEY_ITEM  MUS_RG_OBTAIN_KEY_ITEM
+#define MUS_ROUTE1           MUS_RG_ROUTE1
+#define MUS_OAK_LAB          MUS_RG_OAK_LAB
 #endif  // GUARD_CONSTANTS_SONGS_H

--- a/include/constants/vars.h
+++ b/include/constants/vars.h
@@ -285,6 +285,11 @@
 #define VARS_END                                         0x4102
 #define VARS_COUNT                                       (VARS_END - VARS_START + 1)
 
+// Johto variable aliases using unused Hoenn vars
+#define VAR_NEW_BARK_TOWN_STATE  VAR_DEWFORD_TOWN_STATE
+#define VAR_ROUTE29_STATE        VAR_PACIFIDLOG_TOWN_STATE
+#define VAR_ELM_LAB_STATE        VAR_VERDANTURF_TOWN_STATE
+
 #define SPECIAL_VARS_START            0x8000
 // special vars
 // They are commonly used as parameters to commands, or return values from commands.


### PR DESCRIPTION
## Summary
- add compatibility aliases for FireRed/LeafGreen music constants
- alias some object graphic IDs and variables
- add missing NPC text color header
- define stub event scripts and text used by Johto/Kanto maps

## Testing
- `make` *(fails: `arm-none-eabi-gcc: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687d76a6be688323b751fe5c486b448b