### PR TITLE
Fix build error for johto placeholders

### DIFF
--- a/src/johto_placeholders.c
+++ b/src/johto_placeholders.c
@@ -1,4 +1,5 @@
 #include "global.h"
+#include "event_data.h"
 #include "script.h"
 
 void CopyDayOfWeekStringToVar1(void) {}


### PR DESCRIPTION
## Summary
- include event_data.h in johto_placeholders.c to provide VarSet prototype

## Testing
- `make -j$(nproc)` *(fails: arm-none-eabi-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d8772accc8323ab69cf591eb064d4