### PR TITLE
Add quest log stub specials

### DIFF
--- a/data/maps/PalletTown_RivalsHouse/scripts.inc
+++ b/data/maps/PalletTown_RivalsHouse/scripts.inc
@@ -54,7 +54,7 @@ PalletTown_RivalsHouse_EventScript_GroomMon::
 	lock
 	faceplayer
 	goto_if_ge VAR_0x8004, PARTY_SIZE, PalletTown_RivalsHouse_EventScript_DeclineGrooming
-	specialvar VAR_RESULT, GetPartyMonSpecies
+        specialvar VAR_RESULT, ScriptGetPartyMonSpecies
 	goto_if_eq VAR_RESULT, SPECIES_EGG, PalletTown_RivalsHouse_EventScript_CantGroomEgg
 	msgbox PalletTown_RivalsHouse_Text_LookingNiceInNoTime
 	closemessage

--- a/data/specials.inc
+++ b/data/specials.inc
@@ -601,3 +601,6 @@ gSpecials::
         def_special MomBank
         def_special SetRivalNickname
         def_special IsPlayersMonOfSpeciesInParty
+        def_special GetQuestLogState
+        def_special QuestLog_CutRecording
+        def_special DaisyMassageServices

--- a/src/quest_log_stubs.c
+++ b/src/quest_log_stubs.c
@@ -1,0 +1,19 @@
+#include "global.h"
+#include "event_data.h"
+#include "script.h"
+
+u16 GetQuestLogState(void)
+{
+    // Quest log functionality not implemented. Always return 0.
+    return 0;
+}
+
+void QuestLog_CutRecording(void)
+{
+    // Placeholder for quest log recording logic.
+}
+
+void DaisyMassageServices(void)
+{
+    // Placeholder for Daisy's grooming service.
+}


### PR DESCRIPTION
## Summary
- fix Daisy grooming script to use the correct special name
- add stubs for quest log related specials
- expose these specials in `data/specials.inc`

## Testing
- `make -j2` *(fails: libpng warnings appear but build continues; we aborted early)*

------
https://chatgpt.com/codex/tasks/task_e_687d91c394288323a51de0dfab906bd5