### PR TITLE
Fix standard script call and special name

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -56,8 +56,9 @@
 	@ callstd function names
 	STD_OBTAIN_ITEM = 0
 	STD_FIND_ITEM = 1
-	STD_OBTAIN_DECORATION = 7
-	STD_REGISTER_MATCH_CALL = 8
+        STD_OBTAIN_DECORATION = 7
+        STD_REGISTER_MATCH_CALL = 8
+        STD_RECEIVED_ITEM = 11
 
 	@ Calls the script in gStdScripts at index function.
 	.macro callstd function:req

--- a/data/maps/PalletTown_RivalsHouse/scripts.inc
+++ b/data/maps/PalletTown_RivalsHouse/scripts.inc
@@ -80,7 +80,7 @@ PalletTown_RivalsHouse_EventScript_DeclineGrooming::
 
 PalletTown_RivalsHouse_EventScript_RateMonFriendship::
 	msgbox PalletTown_RivalsHouse_Text_MayISeeFirstMon
-	specialvar VAR_RESULT, GetLeadMonFriendship
+        specialvar VAR_RESULT, GetLeadMonFriendshipScore
 	switch VAR_RESULT
 	case 0, PalletTown_RivalsHouse_EventScript_MonFriendshipLowest
 	case 1, PalletTown_RivalsHouse_EventScript_MonFriendshipLower


### PR DESCRIPTION
## Summary
- define `STD_RECEIVED_ITEM` constant so callstd can compile
- update PalletTown rival house script to use `GetLeadMonFriendshipScore`

## Testing
- `make -j5` *(fails: undefined references)*

------
https://chatgpt.com/codex/tasks/task_e_687d93bd796483238a6efedcd8328bbb