### PR TITLE
Adjust truck intro for non-Hoenn regions

### DIFF
--- a/src/overworld.c
+++ b/src/overworld.c
@@ -1893,7 +1893,10 @@ void CB2_NewGame(void)
     ScriptContext_Init();
     FakeRtc_Init(TIME_STARTING_HOUR, TIME_STARTING_MINUTE);
     UnlockPlayerFieldControls();
-    gFieldCallback = ExecuteTruckSequence;
+    if (gSaveBlock2Ptr->playerRegion == HOENN)
+        gFieldCallback = ExecuteTruckSequence;
+    else
+        gFieldCallback = NULL;
     gFieldCallback2 = NULL;
     DoMapLoadLoop(&gMain.state);
     SetFieldVBlankCallback();


### PR DESCRIPTION
## Summary
- only run the truck intro when starting in Hoenn

## Testing
- `make -j4` *(fails: arm-none-eabi toolchain not fully installed)*

------
https://chatgpt.com/codex/tasks/task_e_687e2a7c87948323a31a41fa381d82cb