### PR TITLE
Add character customization helper script

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -17,6 +17,7 @@
     - [v1.6.x and earlier](tutorials/how_to_new_pokemon_1_6_0.md)
   - [How to use the Testing System](tutorials/how_to_testing_system.md)
   - [How to add new Trainer Slides](tutorials/how_to_new_trainer_slide.md)
+  - [Creating Custom Trainer Sprites](tutorials/how_to_character_customization.md)
   - [Day/Night System FAQ](tutorials/dns.md)
 - [Changelog](./CHANGELOG.md)
     - [1.11.x]()

--- a/docs/tutorials/how_to_character_customization.md
+++ b/docs/tutorials/how_to_character_customization.md
@@ -1,0 +1,32 @@
+# Creating Custom Trainer Sprites
+
+This repository includes a folder at
+`graphics/trainers/Character Customization Resources` with a variety of
+sprite layers for the playable trainer. The `tools/character_customization`
+directory provides a helper script for combining those layers into final
+images.
+
+## Usage
+
+1. Prepare a JSON configuration listing the desired layers. An example is
+   provided at `tools/character_customization/sample_config.json`.
+2. Run `tools/character_customization/create_sheet.py` with the configuration
+   file and an output directory:
+
+```bash
+python3 tools/character_customization/create_sheet.py \
+    tools/character_customization/sample_config.json output_sprites
+```
+
+The script writes one PNG per view (e.g. `front.png`, `back.png`) to the
+specified output directory. Paths in the configuration are relative to the
+`Character Customization Resources` folder.
+
+Layers are drawn in this order:
+1. `base`
+2. `bottom`
+3. `top`
+4. `hair`
+5. `hat`
+
+Any layer can be omitted from the configuration if not needed.

--- a/tools/character_customization/create_sheet.py
+++ b/tools/character_customization/create_sheet.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Compose a custom trainer sprite sheet.
+
+Usage: python3 create_sheet.py CONFIG OUTPUT_DIR
+
+CONFIG is a JSON file containing sprite layer selections for each view.
+Example:
+{
+  "front": {
+    "base": "trainer front female/base/base light.png",
+    "bottom": "trainer front female/bottoms/jeans/jeans navy.png",
+    "top": "trainer front female/tops/hoodie/hoodie red.png",
+    "hair": "trainer front female/hair/Hair 1/1 black.png",
+    "hat": "trainer front female/hats/beanie/beanie purple.png"
+  },
+  "back": {
+    "base": "trainer back female/base/base light.png",
+    "bottom": "trainer back female/clothing/jeans/jeans navy.png",
+    "top": "trainer back female/clothing/hoodie/hoodie red.png",
+    "hair": "trainer back female/hair/Hair 1/1 black.png",
+    "hat": "trainer back female/hat/beanie/beanie purple.png"
+  }
+}
+Paths are relative to the Character Customization Resources directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+from PIL import Image
+
+RES_DIR = pathlib.Path("graphics/trainers/Character Customization Resources")
+
+LAYERS = ["base", "bottom", "top", "hair", "hat"]
+
+
+def compose_layer(paths: list[pathlib.Path]) -> Image.Image:
+    img = Image.open(paths[0]).convert("RGBA")
+    for layer in paths[1:]:
+        if layer.exists():
+            part = Image.open(layer).convert("RGBA")
+            img.alpha_composite(part)
+    return img
+
+
+def build_view(view_cfg: dict[str, str]) -> Image.Image:
+    paths = [RES_DIR / view_cfg.get(key, "") for key in LAYERS if view_cfg.get(key)]
+    if not paths:
+        raise ValueError("No layers provided for view")
+    return compose_layer(paths)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Create a custom sprite sheet")
+    parser.add_argument("config", type=pathlib.Path, help="JSON config file")
+    parser.add_argument("output_dir", type=pathlib.Path, help="Directory for output images")
+    args = parser.parse_args()
+
+    assert args.config.exists(), f"{args.config} does not exist"
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    with args.config.open() as fp:
+        config = json.load(fp)
+
+    for view, view_cfg in config.items():
+        img = build_view(view_cfg)
+        out = args.output_dir / f"{view}.png"
+        img.save(out)
+        print(f"wrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/character_customization/sample_config.json
+++ b/tools/character_customization/sample_config.json
@@ -1,0 +1,16 @@
+{
+  "front": {
+    "base": "trainer front female/base/base  light.png",
+    "bottom": "trainer front female/bottoms/jeans/jeans navy.png",
+    "top": "trainer front female/tops/hoodie/hoodie red.png",
+    "hair": "trainer front female/hair/Hair 1/1 black.png",
+    "hat": "trainer front female/hats/beanie/beanie purple.png"
+  },
+  "back": {
+    "base": "trainer back female/base/base light.png",
+    "bottom": "trainer back female/clothing/jeans/jeans navy.png",
+    "top": "trainer back female/clothing/hoodie/hoodie red.png",
+    "hair": "trainer back female/hair/Hair 1/1 black.png",
+    "hat": "trainer back female/hat/beanie/beanie purple.png"
+  }
+}


### PR DESCRIPTION
## Summary
- add a script that composes player sprite layers
- document how to build custom trainer sprites

## Testing
- `python3 tools/character_customization/create_sheet.py tools/character_customization/sample_config.json custom_output`
- `make check -j5` *(fails: `arm-none-eabi-gcc: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687e50a73f6483239b3bff83b3ad4619