### PR TITLE
Fix dynamic warp freeze

### DIFF
--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -3134,7 +3134,7 @@ void SetObjectInvisibility(u8 localId, u8 mapNum, u8 mapGroup, bool8 invisible)
 {
     u8 objectEventId;
 
-    if (!TryGetObjectEventIdByLocalIdAndMap(localId, mapNum, mapGroup, &objectEventId))
+    if (TryGetObjectEventIdByLocalIdAndMap(localId, mapNum, mapGroup, &objectEventId))
         gObjectEvents[objectEventId].invisible = invisible;
 }
 


### PR DESCRIPTION
## Summary
- ensure `SetObjectInvisibility` only modifies objects that exist

## Testing
- `make -j4` *(fails: `arm-none-eabi-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e7fde30008323ac6f851a1d5f95e2