### PR TITLE
Fix dynamic warp script for truck exit

### DIFF
--- a/data/maps/InsideOfTruck/scripts.inc
+++ b/data/maps/InsideOfTruck/scripts.inc
@@ -30,7 +30,7 @@ InsideOfTruck_EventScript_SetIntroFlagsMale::
 	setflag FLAG_HIDE_LITTLEROOT_TOWN_BRENDANS_HOUSE_RIVAL_SIBLING
 	setflag FLAG_HIDE_LITTLEROOT_TOWN_BRENDANS_HOUSE_2F_POKE_BALL
 	setvar VAR_LITTLEROOT_HOUSES_STATE_BRENDAN, 1
-	setdynamicwarp MAP_LITTLEROOT_TOWN, 3, 10
+        setdynamicwarp MAP_LITTLEROOT_TOWN, 1
 	releaseall
 	end
 
@@ -43,7 +43,7 @@ InsideOfTruck_EventScript_SetIntroFlagsFemale::
 	setflag FLAG_HIDE_LITTLEROOT_TOWN_MAYS_HOUSE_RIVAL_SIBLING
 	setflag FLAG_HIDE_LITTLEROOT_TOWN_MAYS_HOUSE_2F_POKE_BALL
 	setvar VAR_LITTLEROOT_HOUSES_STATE_MAY, 1
-	setdynamicwarp MAP_LITTLEROOT_TOWN, 12, 10
+        setdynamicwarp MAP_LITTLEROOT_TOWN, 0
 	releaseall
 	end
 


### PR DESCRIPTION
## Summary
- correct the dynamic warp destination in `InsideOfTruck` scripts so the player warps using the door warp IDs

## Testing
- `make -j5`

------
https://chatgpt.com/codex/tasks/task_e_687e9d92f55483239f5d4a7181830b62