### PR TITLE
Fix trainer pic reference

### DIFF
--- a/src/data/trainers.party
+++ b/src/data/trainers.party
@@ -16841,7 +16841,7 @@ IVs: 0 HP / 0 Atk / 0 Def / 0 SpA / 0 SpD / 0 Spe
 === TRAINER_LEAF ===
 Name: GREEN
 Class: Rival
-Pic: Green
+Pic: Leaf
 Gender: Female
 Music: Male
 Double Battle: No


### PR DESCRIPTION
## Summary
- correct Leaf trainer entry to use the existing trainer pic constant

## Testing
- `make -j2` *(fails: `arm-none-eabi-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687eb37aa878832395360b504810d287